### PR TITLE
Bug fix: Adjust width of search drop-downs

### DIFF
--- a/app/assets/stylesheets/General/_general.scss
+++ b/app/assets/stylesheets/General/_general.scss
@@ -351,12 +351,12 @@ small.pagination{
   padding-right: 0;
 }
 
-.mol-d4e97117-4bf7-4516-92fa-54bb0abc40fb{
-  padding-right: 7rem;
+.mol-d4e97117-4bf7-4516-92fa-54bb0abc40fb {
+  padding-right: 5.5rem;
 }
 
 .mol-368fb22a-f8c3-45d3-9a05-ed68933d0d2a .form-wrapper .mol-d4e97117-4bf7-4516-92fa-54bb0abc40fb input {
-  width: calc(100% + 7rem);
+  width: calc(100% + 4rem);
 }
 
 .mol-d4e97117-4bf7-4516-92fa-54bb0abc40fb ul {


### PR DESCRIPTION
By a slight adjustment of the width and padding of the search drop-downs we avoid that the text input field (to the left) becomes too small in some browser instances.

This is fix through a width adjustment, but it doesn't solve the real issue which is that the CSS is interpreted differently in different browsers, even between individual Chrome installations. An investigation and complete solution is recommended.

This pull request should be tested in various browsers/browser instances before released (BOKS knows which browser instances to test).